### PR TITLE
Fix E3FP

### DIFF
--- a/base.py
+++ b/base.py
@@ -20,11 +20,13 @@ class FingerprintTransformer(ABC, TransformerMixin, BaseEstimator):
         sparse: bool = False,
         count: bool = False,
         verbose: int = 0,
+        random_state: int = 0,
     ):
         self.n_jobs = effective_n_jobs(n_jobs)
         self.sparse = sparse
         self.count = count
         self.verbose = verbose
+        self.random_state = random_state
 
     def fit(self, X, y=None, **fit_params):
         return self

--- a/base.py
+++ b/base.py
@@ -65,7 +65,7 @@ class FingerprintTransformer(ABC, TransformerMixin, BaseEstimator):
                     for X_sub in args
                 )
 
-            if isinstance(results[0], spsparse.csr_array):
+            if self.sparse:
                 return spsparse.vstack(results)
             else:
                 return np.concatenate(results)

--- a/featurizers/fingerprints.py
+++ b/featurizers/fingerprints.py
@@ -43,9 +43,14 @@ class MorganFingerprint(FingerprintTransformer):
         sparse: bool = False,
         count: bool = False,
         verbose: int = 0,
+        random_state: int = 0,
     ):
         super().__init__(
-            n_jobs=n_jobs, sparse=sparse, count=count, verbose=verbose
+            n_jobs=n_jobs,
+            sparse=sparse,
+            count=count,
+            verbose=verbose,
+            random_state=random_state,
         )
         self.radius = radius
         self.include_chirality = include_chirality
@@ -91,9 +96,14 @@ class AtomPairFingerprint(FingerprintTransformer):
         sparse: bool = False,
         count: bool = False,
         verbose: int = 0,
+        random_state: int = 0,
     ):
         super().__init__(
-            n_jobs=n_jobs, sparse=sparse, count=count, verbose=verbose
+            n_jobs=n_jobs,
+            sparse=sparse,
+            count=count,
+            verbose=verbose,
+            random_state=random_state,
         )
         self.min_distance = min_distance
         self.max_distance = max_distance
@@ -136,9 +146,14 @@ class TopologicalTorsionFingerprint(FingerprintTransformer):
         sparse: bool = False,
         count: bool = False,
         verbose: int = 0,
+        random_state: int = 0,
     ):
         super().__init__(
-            n_jobs=n_jobs, sparse=sparse, count=count, verbose=verbose
+            n_jobs=n_jobs,
+            sparse=sparse,
+            count=count,
+            verbose=verbose,
+            random_state=random_state,
         )
         self.include_chirality = include_chirality
         self.torsion_atom_count = torsion_atom_count
@@ -170,9 +185,18 @@ class TopologicalTorsionFingerprint(FingerprintTransformer):
 
 class MACCSKeysFingerprint(FingerprintTransformer):
     def __init__(
-        self, sparse: bool = False, n_jobs: int = 1, verbose: int = 0
+        self,
+        sparse: bool = False,
+        n_jobs: int = 1,
+        verbose: int = 0,
+        random_state: int = 0,
     ):
-        super().__init__(n_jobs=n_jobs, sparse=sparse, verbose=verbose)
+        super().__init__(
+            n_jobs=n_jobs,
+            sparse=sparse,
+            verbose=verbose,
+            random_state=random_state,
+        )
 
     def _calculate_fingerprint(
         self, X: Union[pd.DataFrame, np.ndarray, list[str]]
@@ -197,8 +221,14 @@ class ERGFingerprint(FingerprintTransformer):
         sparse: bool = False,
         n_jobs: int = None,
         verbose: int = 0,
+        random_state: int = 0,
     ):
-        super().__init__(n_jobs=n_jobs, sparse=sparse, verbose=verbose)
+        super().__init__(
+            n_jobs=n_jobs,
+            sparse=sparse,
+            verbose=verbose,
+            random_state=random_state,
+        )
         self.atom_types = atom_types
         self.fuzz_increment = fuzz_increment
         self.min_path = min_path
@@ -239,11 +269,14 @@ class MAP4Fingerprint(FingerprintTransformer):
         verbose: int = 0,
     ):
         super().__init__(
-            n_jobs=n_jobs, sparse=sparse, count=count, verbose=verbose
+            n_jobs=n_jobs,
+            sparse=sparse,
+            count=count,
+            verbose=verbose,
+            random_state=random_state,
         )
         self.dimensions = dimensions
         self.radius = radius
-        self.random_state = random_state
 
     def _calculate_fingerprint(
         self, X: Union[pd.DataFrame, np.ndarray, list[str]]
@@ -280,11 +313,14 @@ class MHFP(FingerprintTransformer):
         verbose: int = 0,
     ):
         super().__init__(
-            n_jobs=n_jobs, sparse=sparse, count=count, verbose=verbose
+            n_jobs=n_jobs,
+            sparse=sparse,
+            count=count,
+            verbose=verbose,
+            random_state=random_state,
         )
         self.dimensions = dimensions
         self.radius = radius
-        self.random_state = random_state
 
     def _calculate_fingerprint(
         self, X: Union[pd.DataFrame, np.ndarray, list[str]]
@@ -320,17 +356,22 @@ class E3FP(FingerprintTransformer):
         pool_multiplier: float = POOL_MULTIPLIER_DEF,
         rmsd_cutoff: float = RMSD_CUTOFF_DEF,
         max_energy_diff: float = MAX_ENERGY_DIFF_DEF,
-        forcefield: float = FORCEFIELD_DEF,
+        force_field: float = FORCEFIELD_DEF,
         get_values: bool = True,
         is_folded: bool = False,
         fold_bits: int = 1024,
-        standardise: bool = True,
-        seed: int = 0,
         sparse: bool = False,
         n_jobs: int = 1,
         verbose: int = 0,
+        random_state: int = 0,
+        aggregation_type: str = "min_energy",
     ):
-        super().__init__(n_jobs=n_jobs, verbose=verbose, sparse=sparse)
+        super().__init__(
+            n_jobs=n_jobs,
+            verbose=verbose,
+            sparse=sparse,
+            random_state=random_state,
+        )
         self.bits = bits
         self.radius_multiplier = radius_multiplier
         self.rdkit_invariants = rdkit_invariants
@@ -339,12 +380,11 @@ class E3FP(FingerprintTransformer):
         self.pool_multiplier = pool_multiplier
         self.rmsd_cutoff = rmsd_cutoff
         self.max_energy_diff = max_energy_diff
-        self.forcefield = forcefield
+        self.force_field = force_field
         self.get_values = get_values
         self.is_folded = is_folded
         self.fold_bits = fold_bits
-        self.standardise = standardise
-        self.seed = seed
+        self.aggregation_type = aggregation_type
 
     def _calculate_fingerprint(
         self, X: Union[pd.DataFrame, np.ndarray]
@@ -358,9 +398,9 @@ class E3FP(FingerprintTransformer):
             pool_multiplier=self.pool_multiplier,
             rmsd_cutoff=self.rmsd_cutoff,
             max_energy_diff=self.max_energy_diff,
-            forcefield=self.forcefield,
+            forcefield=self.force_field,
             get_values=self.get_values,
-            seed=self.seed,
+            seed=self.random_state,
         )
 
         result = []
@@ -374,8 +414,6 @@ class E3FP(FingerprintTransformer):
                 mol = MolFromSmiles(x)
 
             mol.SetProp("_Name", smiles)
-            if self.standardise:
-                mol = mol_to_standardised_mol(mol)
             mol = PropertyMol(mol)
             mol.SetProp("_SMILES", smiles)
 
@@ -391,8 +429,12 @@ class E3FP(FingerprintTransformer):
                 },
             )
 
-            energies = values[2]
-            fp = fps[np.argmin(energies)]
+            # TODO: in future - add other aggregation types
+            if self.aggregation_type == "min_energy":
+                energies = values[2]
+                fp = fps[np.argmin(energies)]
+            else:
+                fp = fps[0]
 
             if self.is_folded:
                 fp = fp.fold(self.fold_bits)

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -330,6 +330,16 @@ def test_mhfp6_sparse_count_fingerprint(
 def test_e3fp(example_molecules):
     X = example_molecules
 
+    e3fp_fp = E3FP(
+        4096,
+        1.5,
+        is_folded=True,
+        n_jobs=-1,
+        verbose=0,
+        sparse=False,
+    )
+    X_emf = e3fp_fp.transform(X)
+
     confgen_params = {
         "first": 1,
         "num_conf": NUM_CONF_DEF,
@@ -345,24 +355,12 @@ def test_e3fp(example_molecules):
         "radius_multiplier": 1.5,
         "rdkit_invariants": True,
     }
-    e3fp_fp = E3FP(
-        **confgen_params,
-        **fprint_params,
-        is_folded=True,
-        standardise=True,
-        n_jobs=-1,
-        verbose=0,
-        sparse=False,
-    )
-    X_emf = e3fp_fp.transform(X)
-
     X_seq = []
     conf_gen = ConformerGenerator(**confgen_params)
     for smiles in X:
         # creating molecule object
         mol = Chem.MolFromSmiles(smiles)
         mol.SetProp("_Name", smiles)
-        mol = mol_to_standardised_mol(mol)
         mol = PropertyMol(mol)
         mol.SetProp("_SMILES", smiles)
 
@@ -382,6 +380,16 @@ def test_e3fp(example_molecules):
 def test_e3fp_sparse(example_molecules):
     X = example_molecules
 
+    e3fp_fp = E3FP(
+        4096,
+        1.5,
+        is_folded=True,
+        n_jobs=-1,
+        verbose=0,
+        sparse=True,
+    )
+    X_emf = e3fp_fp.transform(X)
+
     confgen_params = {
         "first": 1,
         "num_conf": NUM_CONF_DEF,
@@ -397,24 +405,12 @@ def test_e3fp_sparse(example_molecules):
         "radius_multiplier": 1.5,
         "rdkit_invariants": True,
     }
-    e3fp_fp = E3FP(
-        **confgen_params,
-        **fprint_params,
-        is_folded=True,
-        standardise=True,
-        n_jobs=-1,
-        verbose=0,
-        sparse=True,
-    )
-    X_emf = e3fp_fp.transform(X)
-
     X_seq = []
     conf_gen = ConformerGenerator(**confgen_params)
     for smiles in X:
         # creating molecule object
         mol = Chem.MolFromSmiles(smiles)
         mol.SetProp("_Name", smiles)
-        mol = mol_to_standardised_mol(mol)
         mol = PropertyMol(mol)
         mol.SetProp("_SMILES", smiles)
 

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -14,6 +14,7 @@ from rdkit import Chem
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
 from rdkit.Chem.rdReducedGraphs import GetErGFingerprint
 from scipy.sparse import csr_array
+from scipy.sparse import vstack
 
 from featurizers.fingerprints import (
     E3FP,
@@ -353,7 +354,7 @@ def test_e3fp(example_molecules):
         n_jobs=-1,
         verbose=0
     )
-    X_e3fp = e3fp_fp.transform(X)
+    X_emf = e3fp_fp.transform(X)
 
     confgen_params = {
         "num_conf": NUM_CONF_DEF,
@@ -378,18 +379,11 @@ def test_e3fp(example_molecules):
         ],
         dtype=object,
     )
+
     X_seq = X_seq.flatten()
+    X_seq = vstack([fp.to_vector() for fp in X_seq])
 
-    if type(X_seq[0]) is list:
-        new_X_seq = []
-        for x_seq in X_seq:
-            for fp in x_seq:
-                new_X_seq.append(fp)
-
-        X_seq = np.array(new_X_seq, dtype=object)
-
-    for i in range(len(X_e3fp)):
-        assert tanimoto(X_e3fp[i], X_seq[i]) == 1
+    assert np.all(X_emf.toarray() == X_seq.toarray())
 
 
 def test_input_validation(example_molecules):


### PR DESCRIPTION
We've discovered some issues in E3FP fingerprint.
The fingerprint couldn't handle more than 1 data element/thread as it returned lists of indices that couldn't be aggregated. Current implementation fixes that issue and returns a sparse arrays that can then be easily aggregated in the thread and outside to stack the results. 

However, this implementation doesn't allow us to return the Energy parameter generated by conformers. I don't know how to fix that without redesigning the result function of the fingerprint that returns either sparse vectors or numpy arrays instead of more complex objects.

The issue of output size being potentially bigger than the input is still not fixed